### PR TITLE
fix(deps): bump jsonwebtoken from 8.5.1 to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "express-fileupload": "^1.3.1",
     "express-graphql": "^0.12.0",
     "html-pdf-node": "^1.0.8",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "libxmljs": "^0.19.7",
     "md5": "^2.3.0",
     "mongodb": "^4.3.1",


### PR DESCRIPTION
## Security Fix

Bumps `jsonwebtoken` from `8.5.1` to `9.0.0` to address 3 vulnerabilities.

| ID | Severity | Summary |
|----|----------|---------|
| GHSA-8cf7-32gw-wr33 | HIGH | jsonwebtoken unrestricted key type could lead to legacy keys usage  |
| GHSA-hjrf-2m68-5959 | MEDIUM | jsonwebtoken's insecure implementation of key retrieval function could lead to Forgeable Public/Private Tokens from RSA to HMAC |
| GHSA-qwph-4952-7xr6 | MEDIUM | jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify() |

---
_Generated by [NodeGuard](https://github.com/nodeguard/nodeguard)_